### PR TITLE
Find the data library in the script directory

### DIFF
--- a/cgHeliParm.py
+++ b/cgHeliParm.py
@@ -17,8 +17,15 @@ import argparse
 import MDAnalysis
 import sys
 import time
+import os
 start_time = time.time()
 import mdreader
+
+# Locate the directory in which the script is stored.
+# The __file__ variable contains the path to the python file,
+# we save the directory part of that path. This is useful latter on to locate
+# the data library.
+SCRIPT_DIRECTORY = os.path.dirname(__file__)
 
 def lsfit(residue_name,residue_number):
     base = mol.residues.residues[residue_number]
@@ -181,7 +188,7 @@ def stepFrame(o1,R1,o2,R2):
 
 
 # input files
-library_path = "./data/"
+library_path = os.path.join(SCRIPT_DIRECTORY, "data")
 mol = mdreader.MDreader(description='Calculate helical parameters for dsDNA')
 mol.setargs(o="")
 

--- a/cgHeliParmPDB.py
+++ b/cgHeliParmPDB.py
@@ -5,7 +5,14 @@ import argparse
 import MDAnalysis
 import sys
 import time
+import os
 start_time = time.time()
+
+# Locate the directory in which the script is stored.
+# The __file__ variable contains the path to the python file,
+# we save the directory part of that path. This is useful latter on to locate
+# the data library.
+SCRIPT_DIRECTORY = os.path.dirname(__file__)
 
 parser = argparse.ArgumentParser(description='Calculate helical parameters for dsDNA')
 parser.add_argument('-i', dest="pdb", metavar='<.pdb file>', 
@@ -202,7 +209,7 @@ def write2ser(data, file):
 
 # input files
 #ifile = raw_input('PDB file: ')
-library_path = "./data/"
+library_path = os.path.join(SCRIPT_DIRECTORY, "data")
 mol = MDAnalysis.Universe(args.pdb)
 total_res = len(mol.residues.resids)
 basepairs = total_res/2

--- a/cgHeliParmPDB_json.py
+++ b/cgHeliParmPDB_json.py
@@ -8,6 +8,13 @@ import sys
 import time
 import json 
 import pandas as pd 
+import os
+
+# Locate the directory in which the script is stored.
+# The __file__ variable contains the path to the python file,
+# we save the directory part of that path. This is useful latter on to locate
+# the data library.
+SCRIPT_DIRECTORY = os.path.dirname(__file__)
 
 start_time = time.time()
 parser = argparse.ArgumentParser(description='Calculate helical parameters for dsDNA')
@@ -200,7 +207,7 @@ def write2json(data,file):
     
 # input files
 #ifile = raw_input('PDB file: ')
-library_path = "./data/"
+library_path = os.path.join(SCRIPT_DIRECTORY, "data")
 mol = MDAnalysis.Universe(args.pdb)
 total_res = len(mol.residues.resids)
 basepairs = total_res/2

--- a/cgHeliParm_json.py
+++ b/cgHeliParm_json.py
@@ -17,11 +17,17 @@ import argparse
 import MDAnalysis
 import sys
 import time
+import os
 start_time = time.time()
 import mdreader
 import json
 import pandas as pd
 
+# Locate the directory in which the script is stored.
+# The __file__ variable contains the path to the python file,
+# we save the directory part of that path. This is useful latter on to locate
+# the data library.
+SCRIPT_DIRECTORY = os.path.dirname(__file__)
 
 def lsfit(residue_name,residue_number):
     base = mol.residues.residues[residue_number]
@@ -189,7 +195,7 @@ def write2json(data, file):
         json.dump(dlist, outfile)
     
 # input files
-library_path = "./data/"
+library_path = os.path.join(SCRIPT_DIRECTORY, "data")
 mol = mdreader.MDreader(description='Calculate helical parameters for dsDNA')
 mol.setargs(o="")
 


### PR DESCRIPTION
Prior to this commit, the "data" directory is looked for in the working
directory. As a consequence, cgHeliParm has to be called from its own
directory, or the data directory has to be copied alongside the
trajectory.

This commit introduce the SCRIPT_DIRECTORY variable at the beginning of
all the cgHeliParm scripts. This variable stores the path to the
directory were chHeliParm sits. Thanks to this variable, the data
directory can be looked for next to the script rather than in the
working directory; so cgHeliParm can be called from any directory.

This assumes that the content of data is not to change on a
trajectory-per-trajectory basis and that it is inherently attached to
the program rather than to the trajectory.